### PR TITLE
Fix parser of image tags

### DIFF
--- a/dist/habitica-markdown.js
+++ b/dist/habitica-markdown.js
@@ -7291,7 +7291,7 @@ module.exports = function image(state, silent) {
     token          = state.push('image', 'img', 0);
     token.attrs    = attrs = [ [ 'src', href ], [ 'alt', '' ] ];
     token.children = tokens;
-    token.content  = content;
+    token.content  = state.md.utils.escapeHtml(content);
 
     if (title) {
       attrs.push([ 'title', title ]);


### PR DESCRIPTION
Fixes a bug discussed by email.

### Changes
- The parser of images becomes more secure.

----
UUID: af1477b6-509a-4611-b851-d7a8e3a9c02a