### PR TITLE
Upgrade markdown-it version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "habitica-markdown-emoji": "1.2.4",
     "markdown-it": "8.4.2",
     "markdown-it-link-attributes": "1.0.0",
-    "markdown-it-linkify-images": "^1.1.0"
+    "markdown-it-linkify-images": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "habitica-markdown-emoji": "1.2.4",
-    "markdown-it": "8.2.1",
+    "markdown-it": "8.4.2",
     "markdown-it-link-attributes": "1.0.0",
     "markdown-it-linkify-images": "^1.1.0"
   }


### PR DESCRIPTION
Continuation of #83 as recommended by @crookedneighbor. Instead of making a change in `dist` that'll just get overwritten, this updates `package.json` to use version 8.4.2 of `markdown-it`.

Note that `package-lock.json` will need to be updated in `master` after merge--didn't think it'd make sense to include that diff in the PR. But let me know if I should add it!

CC @HydeHunter2