### PR TITLE
Fix for mention in link followed by punctuation

### DIFF
--- a/lib/mentionsPlugin.js
+++ b/lib/mentionsPlugin.js
@@ -7,7 +7,7 @@ const isLinkOrEmail = require('./util/isLinkOrEmail');
 const mentionRegex = /^@[\w-]+/;
 const whiteSpaceRegex = /\s+/;
 
-function partOfLinkOrEmail (pretext, text, md) {
+function partOfLinkOrEmail (mention, pretext, text, md) {
   if (!pretext || pretext.charCodeAt(pretext.length - 1) === 0x20 /* ' ' */) {
     return false;
   }
@@ -17,7 +17,7 @@ function partOfLinkOrEmail (pretext, text, md) {
   const prefix = preTextWords[preTextWords.length - 1];
   const possibleLink = prefix + atWord;
 
-  return isLinkOrEmail(possibleLink, md.linkify);
+  return isLinkOrEmail(mention, possibleLink, md.linkify);
 }
 
 /**
@@ -30,13 +30,19 @@ function parseMentions (state, silent) {
     return false;
   }
 
-  const text = state.src.slice(state.pos);
-  const match = text.match(mentionRegex);
-
-  if (!match || partOfLinkOrEmail(state.src.substr(0, state.pos), text, state.md)) {
+  const textUntilAt = state.src.slice(0, state.pos);
+  const textAfterAt = state.src.slice(state.pos);
+  
+  const match = textAfterAt.match(mentionRegex);
+  if (!match) {
     return false;
   }
+
   const mention = match[0];
+  if (partOfLinkOrEmail(mention, textUntilAt, textAfterAt, state.md)) {
+    return false;
+  }
+
   state.pos += mention.length;
 
   if (!silent) {

--- a/lib/mentionsPlugin.js
+++ b/lib/mentionsPlugin.js
@@ -32,7 +32,7 @@ function parseMentions (state, silent) {
 
   const textUntilAt = state.src.slice(0, state.pos);
   const textAfterAt = state.src.slice(state.pos);
-  
+
   const match = textAfterAt.match(mentionRegex);
   if (!match) {
     return false;

--- a/lib/mentionsPlugin.js
+++ b/lib/mentionsPlugin.js
@@ -34,15 +34,11 @@ function parseMentions (state, silent) {
   const textAfterAt = state.src.slice(state.pos);
 
   const match = textAfterAt.match(mentionRegex);
-  if (!match) {
+  if (!match || partOfLinkOrEmail(match[0], textUntilAt, textAfterAt, state.md)) {
     return false;
   }
 
   const mention = match[0];
-  if (partOfLinkOrEmail(mention, textUntilAt, textAfterAt, state.md)) {
-    return false;
-  }
-
   state.pos += mention.length;
 
   if (!silent) {

--- a/lib/mentionsPlugin.js
+++ b/lib/mentionsPlugin.js
@@ -2,22 +2,22 @@
  * Plugin to parse `@user` mentions in habitica and turn them into renderable tokens.
  */
 
-const isLinkOrEmail = require('./util/isLinkOrEmail');
+const isMentionInLinkOrEmail = require('./util/isLinkOrEmail');
 
 const mentionRegex = /^@[\w-]+/;
 const whiteSpaceRegex = /\s+/;
 
-function partOfLinkOrEmail (mention, pretext, text, md) {
-  if (!pretext || pretext.charCodeAt(pretext.length - 1) === 0x20 /* ' ' */) {
+function partOfLinkOrEmail (mention, textUntilAt, textAfterAt, md) {
+  if (!textUntilAt || textUntilAt.charCodeAt(textUntilAt.length - 1) === 0x20 /* ' ' */) {
     return false;
   }
 
-  const atWord = text.split(whiteSpaceRegex)[0];
-  const preTextWords = pretext.split(whiteSpaceRegex);
+  const atWord = textAfterAt.split(whiteSpaceRegex)[0];
+  const preTextWords = textUntilAt.split(whiteSpaceRegex);
   const prefix = preTextWords[preTextWords.length - 1];
   const possibleLink = prefix + atWord;
 
-  return isLinkOrEmail(mention, possibleLink, md.linkify);
+  return isMentionInLinkOrEmail(mention, possibleLink, md.linkify);
 }
 
 /**

--- a/lib/util/createMdInstance.js
+++ b/lib/util/createMdInstance.js
@@ -4,8 +4,6 @@ const linkifyImagesPlugin = require('markdown-it-linkify-images');
 const linkAttributesPlugin = require('markdown-it-link-attributes');
 const emojiPlugin = require('habitica-markdown-emoji');
 
-const isLinkOrEmail = require('./isLinkOrEmail');
-
 function createMdInstance (options) {
   const mdOptions = options || {};
   mdOptions.linkify = mdOptions.linkify || true;
@@ -23,8 +21,6 @@ function createMdInstance (options) {
       imgClass: 'markdown-img',
     })
     .use(emojiPlugin);
-
-  md.isLinkOrEmail = text => isLinkOrEmail(text, md.linkify);
 
   return md;
 }

--- a/lib/util/isLinkOrEmail.js
+++ b/lib/util/isLinkOrEmail.js
@@ -1,10 +1,10 @@
 /*
  * Uses `linkify` to test whether the @mention is part of a link or e-mail address
  */
-function isLinkOrEmail (text, linkify) {
+function isLinkOrEmail (mention, text, linkify) {
   // Using match i.o. test since test is approximation only (Doesn't discard www.google.com@user)
   const match = linkify.match(text);
-  return match && match[0].text === text;
+  return match && match[0].text.includes(mention);
 }
 
 module.exports = isLinkOrEmail;

--- a/lib/util/isLinkOrEmail.js
+++ b/lib/util/isLinkOrEmail.js
@@ -1,10 +1,10 @@
 /*
  * Uses `linkify` to test whether the @mention is part of a link or e-mail address
  */
-function isLinkOrEmail (mention, text, linkify) {
+function isMentionInLinkOrEmail (mention, text, linkify) {
   // Using match i.o. test since test is approximation only (Doesn't discard www.google.com@user)
   const match = linkify.match(text);
   return match && match[0].text.includes(mention);
 }
 
-module.exports = isLinkOrEmail;
+module.exports = isMentionInLinkOrEmail;

--- a/test/lib/mentionsPlugin.test.js
+++ b/test/lib/mentionsPlugin.test.js
@@ -39,6 +39,14 @@ describe('mentionsPlugin', () => {
       expect(mentionTokens.length).to.equal(0);
     });
 
+    it('does not parse mentions in e-mail addresses ending in punctuation', () => {
+      const text = 'send an e-mail to nevermind@user.com!';
+
+      const mentionTokens = findMentionTokens(md.parse(text));
+
+      expect(mentionTokens.length).to.equal(0);
+    });
+
     it('parses mentions in e-mail addresses with underscore', () => {
       const text = 'please contact@_user_.I think I missed some spaces';
 


### PR DESCRIPTION
Added a test for an edge case that was not parsing properly. Changed isLinkOrEmail to check if the link contains a mention. All tests (including new one) are passing.

Fixes https://github.com/HabitRPG/habitica/issues/12437
Fixes https://github.com/HabitRPG/habitica-markdown/issues/91